### PR TITLE
Bug Fix - Header Spacing

### DIFF
--- a/pivotal/style.html
+++ b/pivotal/style.html
@@ -1,4 +1,7 @@
 <style>
+    html {
+        scroll-behavior: smooth;
+    }	
     .header-dropdown {
         font-size: .75em
     }
@@ -120,6 +123,10 @@
         font-weight: 700
     }
 
+    label.md-nav__title {
+        margin: 10.5px 0 0 0;
+    }
+
     @media only screen and (min-width: 76.1875em) {
         label.md-nav__title.md-nav__title--site {
             display: none
@@ -192,10 +199,24 @@
     .md-typeset .md-footer-social {
         font-size: .64rem
     }
-
+    
     .md-typeset [id]:target:before {
-        margin-top: -136px !important;
-        padding-top: 136px !important;
+        margin-top: -205px !important;
+        padding-top: 205px !important;
+    }
+
+    @media only screen and (max-width: 125em) { 
+        .md-typeset [id]:target:before {
+            margin-top: -188px !important;
+            padding-top: 188px !important;
+        }
+    }
+    
+    @media only screen and (max-width: 100em) {
+        .md-typeset [id]:target:before {
+            margin-top: -170px !important;
+            padding-top: 170px !important;
+        }
     }
 
     .md-footer-social {


### PR DESCRIPTION
This is a fix to a hack introduced to align article headers under the
menu bars at the top of the layout when anchor links (like the TOC
links) are clicked.

Reference issue: https://github.com/pivotal/mkdocs-pivotal-theme/issues/6

Changes:
* Aligned the TOC links with the main menu links so that they have
identical vertical positions (line 126)
* Adjusted margin/padding hack to align headers with menu/TOC (line 204)
* Added media queries based on other breakpoints I found in the file and
observed in the browser (line 208)
* Added smooth scroll behavior for a better UX - users can easier keep
track of scroll position when the jump isn't instantaneous (line 2)